### PR TITLE
Add the other java-generator artifacts to the bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A bom maven dependency for lightblue. Use it to manage lightblue dependency vers
        <dependency>
           <groupId>com.redhat.lightblue</groupId>
           <artifactId>lightblue-bom</artifactId>
-          <version>1.11.0-SNAPSHOT</version>
+          <version>2.6.7</version>
           <type>pom</type>
           <scope>import</scope>
        </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -76,6 +76,23 @@
 				<artifactId>lightblue-java-generator-bin</artifactId>
 				<version>${java-generator.version}</version>
 			</dependency>
+            <dependency>
+                <groupId>com.redhat.lightblue.generator</groupId>
+                <artifactId>lightblue-java-generator</artifactId>
+                <version>${java-generator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.lightblue.generator</groupId>
+                <artifactId>lightblue-java-generator-api</artifactId>
+                <version>${java-generator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.lightblue.generator</groupId>
+                <artifactId>lightblue-java-generator-lib</artifactId>
+                <version>${java-generator.version}</version>
+                <scope>test</scope>
+            </dependency>
+
 			<dependency>
             	<groupId>org.esbtools.lightblue-notification-hook</groupId>
             	<artifactId>lightblue-notification-hook-model</artifactId>


### PR DESCRIPTION
In the previous PR, I missed the following generator dependencies.

lightblue-java-generator
lightblue-java-generator-api
lightblue-java-generator-lib


Signed-off-by: David Lanouette <David.Lanouette@RedHat.com>